### PR TITLE
Fixed unexpected behaviour

### DIFF
--- a/src/Control/Monad/Validation.hs
+++ b/src/Control/Monad/Validation.hs
@@ -92,7 +92,7 @@ setMempty setter a = set setter a mempty
 neConcat :: Foldable f => (a -> a -> a) -> f a -> Maybe a
 neConcat f a
   | F.null a  = Nothing
-  | otherwise = Just $ F.foldl1 f a
+  | otherwise = Just $ F.foldr1 f a
 
 textErrors :: [Text] -> Maybe Text
 textErrors = neConcat (\a b -> a <> ", " <> b)

--- a/src/Control/Monad/Validation.hs
+++ b/src/Control/Monad/Validation.hs
@@ -81,25 +81,18 @@ mmAppend (MonoidMap a) (MonoidMap b) = MonoidMap $ M.unionWith (<>) a b
 -- | Convenient for 'vZoom' as first artument. Will prevent generation
 -- of map with 'mempty' values
 mmSingleton :: (Eq v, Monoid v, Ord k) => k -> v -> MonoidMap k v
-mmSingleton k = memptyWrap mempty $ MonoidMap . M.singleton k
+mmSingleton k v
+  | v == mempty = mempty
+  | otherwise   = MonoidMap . M.singleton k $ v
 
 -- | Set given value to 'mempty'
 setMempty :: (Monoid s) => ASetter' s a -> a -> s
 setMempty setter a = set setter a mempty
 
-memptyWrap :: (Eq a, Monoid a) => b -> (a -> b) -> a -> b
-memptyWrap b f a
-  | a == mempty = b
-  | otherwise = f a
-
--- | If given container is not 'mempty', then use given function to
--- append all its elements and return 'Just' result
-neConcat
-  :: (Foldable f, Eq (f a), Monoid a, Monoid (f a))
-  => (a -> a -> a)
-  -> f a
-  -> Maybe a
-neConcat f = memptyWrap Nothing (Just . F.foldl' f mempty)
+neConcat :: Foldable f => (a -> a -> a) -> f a -> Maybe a
+neConcat f a
+  | F.null a  = Nothing
+  | otherwise = Just $ F.foldl1 f a
 
 textErrors :: [Text] -> Maybe Text
 textErrors = neConcat (\a b -> a <> ", " <> b)


### PR DESCRIPTION
the `textErrors` and `neConcat` don't work the way the functions suggest. This wasn't an issue since these functions are not used in our projects.

Previously `textErrors` would work as follows:

```haskell
textErrors ["one", "two"]
-- Just ", one, two"
```

This is probably not the intended result (the extra `, ` at the beginning).


The name `neConcat` suggests that the elements would be concatenated using the given function, but due to the way it was implemented, it would also concatenate an extra empty string at the beginning. This is not an issue until we start concatenating in some custom way (like with a `, ` between the elements), since `mempty` is only a zero for the `<>` function.

The way to fix this is to use the `foldl1` function (there seems to be no strict version for reasons that are beyond me). 

But the problem with this is that nothing guaranties that the `mempty` for the given container is actually an empty container. Furthermore, nothing guaranties that the `Eq` instance actually compares the contained elements.

So, we effectively have multiple point of failure in knowing that the container is non-empty. This would lead to `foldl1` failing at runtime.

The right approach to solve this would be to check for non-emptiness with the `Foldable` instance itself with `null` (which is guarantied to correspond with `foldl1` not failing).

If we take this approach, the two `Monoid` and one `Eq` instances were not actually needed.