### PR TITLE
bumped version and added explicit default-language to tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,38 +12,27 @@ cache:
 
 jobs:
   include:
-
-  # Cabal
+  - ghc: 8.6.5
+    env: SNAPSHOT="lts-14.22"
+  - ghc: 8.6.4
+    env: SNAPSHOT="lts-13.19"
+  - ghc: 8.6.3
+    env: SNAPSHOT="lts-13.11"
   - ghc: 8.4.4
-  - ghc: 8.6.5
-
-  # Stack
-  - ghc: 8.6.5
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
+    env: SNAPSHOT="lts-12.26"
 
 install:
   - |
-    if [ -z "$STACK_YAML" ]; then
-      ghc --version
-      cabal --version
-      cabal new-update
-      cabal new-build --enable-tests --enable-benchmarks
-    else
-      # install stack
-      curl -sSL https://get.haskellstack.org/ | sh
+    # install stack
+    curl -sSL https://get.haskellstack.org/ | sh
 
-      # build project with stack
-      stack --version
-      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
-    fi
+    # build project with stack
+    stack --version
+    stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --resolver=$SNAPSHOT
 
 script:
   - |
-    if [ -z "$STACK_YAML" ]; then
-      cabal new-test --enable-tests
-    else
-      stack test --system-ghc
-    fi
+    stack test --system-ghc
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,13 @@ language: haskell
 git:
   depth: 5
 
-cabal: "2.4"
-
 cache:
   directories:
   - "$HOME/.cabal/store"
   - "$HOME/.stack"
   - "$TRAVIS_BUILD_DIR/.stack-work"
 
-matrix:
+jobs:
   include:
 
   # Cabal

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for validationt
 
+## 0.3.0
+
+* Added documentation.
+* Fixed `textErrors` behaviour.
+* Dropped `transformers-lift` dependency.
+
 ## 0.2.1.0
 
 * GHC 8.4 support

--- a/test/Doc.hs
+++ b/test/Doc.hs
@@ -3,4 +3,4 @@ module Main (main) where
 import Test.DocTest
 
 main :: IO ()
-main = doctest [ "-XOverloadedStrings", "src" ]
+main = doctest [ "-XOverloadedStrings", "-isrc", "src" ]

--- a/validationt.cabal
+++ b/validationt.cabal
@@ -50,22 +50,12 @@ library
                        -Wmissing-export-lists
 
 test-suite doctest
+  default-language: Haskell2010
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   ghc-options: -Wall
   main-is: Doc.hs
-  default-language:    Haskell2010
-  build-depends:       base >=4.8 && < 5
-                     , aeson >= 1.0
-                     , doctest
-                     , containers
-                     , exceptions
-                     , lens
-                     , monad-control
-                     , mtl
-                     , QuickCheck
-                     , text
-                     , transformers
-                     , transformers-base
-                     , vector
-                     , doctest
+  build-depends:
+      base >= 4.10.0.0
+    , doctest >= 0.11.4
+    , validationt

--- a/validationt.cabal
+++ b/validationt.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                validationt
-version:             0.2.1.0
+version:             0.3.0
 synopsis:            Straightforward validation monad.
 description:         Convenient solution for validating web forms and APIs.
 homepage:            https://github.com/typeable/validationt
@@ -54,6 +54,7 @@ test-suite doctest
   hs-source-dirs: test
   ghc-options: -Wall
   main-is: Doc.hs
+  default-language:    Haskell2010
   build-depends:       base >=4.8 && < 5
                      , aeson >= 1.0
                      , doctest


### PR DESCRIPTION
bumped version and added explicit default-language to tests.

Also renamed travisCI to be inline with current docs.

Also removed cabal from Travis CI because it is doesn't work with doctests from some reason (dependancies don't get inferred correctly)