### PR TITLE
Added promoting warnings to errors

### DIFF
--- a/validationt.cabal
+++ b/validationt.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                validationt
-version:             0.3.0
+version:             0.3.1
 synopsis:            Straightforward validation monad.
 description:         Convenient solution for validating web forms and APIs.
 homepage:            https://github.com/typeable/validationt


### PR DESCRIPTION
This can be useful when you want some part of the validation to block further execution. (Very useful when validation is heavily reused and in some part of code warnings should stop execution)

The "correct" way of solving this usecase would be to have operations like `vError` and `vWarning` work with a polymorphic monad (not a concrete `ValidationT`), and stopping on warnings would be a behaviour of **an** instance.